### PR TITLE
Major refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+.*.sw?
+.cache
+.molecule
+.vagrant
+pytestdebug.log
+venv

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 OCAD University
+Copyright (c) OCAD University
+Copyright (c) Raising the Floor International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,40 +1,19 @@
 Ansible Role: sshd
-=========
+==================
 
 Configures the OpenSSH daemon.
 
 Requirements
 ------------
 
-None.
+ * CentOS 7.x
+ * systemd
+ * SELinux
 
 Role Variables
 --------------
 
-    sshd_protocol
-    sshd_ports       # list
-    sshd_listen_ips  # list -- optional
-    sshd_allowusers  # list -- optional
-    
-    sshd_permit_root
-    sshd_password_auth
-    sshd_challenge_response_auth
-    sshd_gssapi_auth
-    sshd_gssapi_cleanup_credentials
-    
-    sshd_use_dns
-    sshd_use_pam
-    sshd_x11_forwarding
-    sshd_print_motd
-
-    sshd_maxstartups
-
-These variables are set to OpenSSH default settings initially.
-
-Dependencies
-------------
-
-None.
+See defaults/main.yml
 
 Example Playbook
 ----------------
@@ -42,14 +21,16 @@ Example Playbook
     - hosts: localhost
       become: yes
       roles:
+        - sshd
 
-        - role: sshd
-          sshd_ports: [ 22, 2222 ]
-          sshd_listen_ips: [ 127.0.0.1 ]
-          sshd_permit_root: no
-          sshd_password_auth: no
-          sshd_challenge_response_auth: no
-          sshd_gssapi_auth: no
-          sshd_use_dns: no
-          sshd_x11_forwarding: no
-          sshd_print_motd: no
+Tests
+-----
+
+Use [molecule](https://github.com/metacloud/molecule) to test this role. 
+
+Because this role depends on systemd and SELinux, only a Vagrant provider is configured at the moment.
+
+License
+-------
+
+MIT

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Ansible Role: sshd
 
 Configures the OpenSSH daemon.
 
+
 Requirements
 ------------
 
@@ -10,10 +11,70 @@ Requirements
  * systemd
  * SELinux
 
+
 Role Variables
 --------------
 
-See defaults/main.yml
+TCP port number that should be used by sshd
+
+    sshd_port: 22
+
+List of IPs to listen on (useful for restricting SSH on multi-homed servers) (empty list means listen on all IPs)
+
+    sshd_listen_addresses: []
+
+Only allow certain users to connect (empty list means allow all users)
+
+    sshd_allowusers: []
+
+Force certain groups of users to be SFTP-only (empty list means no users are forced to use SFTP)
+
+    sshd_sftp_only_groups: []
+
+Whether to permit root logins
+
+    sshd_permit_root: no
+
+Whether password authentication is allowed (RFC4252)
+
+    sshd_password_auth: no
+
+Allows 'keyboard-interactive' authentication (RFC4256)
+
+    sshd_challenge_response_auth: no
+
+Whether user authentication based on GSSAPI is allowed (needed for Kerberos)
+
+    sshd_gssapi_auth: no
+
+If sshd should destroy the user's GSSAPI credentials on logout
+
+    sshd_gssapi_cleanup_credentials: no
+
+Maximum concurrent unauthenticated connections (start:rate:full)
+
+    sshd_maxstartups: "10:30:100"
+
+Verify that reverse DNS lookup matches the IP address back
+
+    sshd_use_dns: no
+
+Use PAM (don't change unless using other authentication methods)
+
+    sshd_use_pam: yes
+
+Allow X11 forwarding over SSH
+
+    sshd_x11_forwarding: no
+
+Print /etc/motd when user logs in interactively
+
+    sshd_print_motd: yes
+
+Verbosity level (valid values: QUIET, FATAL, ERROR, INFO, VERBOSE, DEBUG, DEBUG1, DEBUG2, and DEBUG3)
+
+    sshd_log_level: 'INFO'
+
 
 Example Playbook
 ----------------
@@ -23,12 +84,14 @@ Example Playbook
       roles:
         - sshd
 
+
 Tests
 -----
 
 Use [molecule](https://github.com/metacloud/molecule) to test this role. 
 
 Because this role depends on systemd and SELinux, only a Vagrant provider is configured at the moment.
+
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,6 @@ sshd_use_dns: no
 sshd_use_pam: yes
 
 # Allow X11 forwarding over SSH
-
 sshd_x11_forwarding: no
 
 # Print /etc/motd when user logs in interactively

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ sshd_challenge_response_auth: no
 # Whether user authentication based on GSSAPI is allowed (needed for Kerberos)
 sshd_gssapi_auth: no
 
-# Destroy user's credentials on logout
+# Destroy user's GSSAPI credentials on logout
 sshd_gssapi_cleanup_credentials: no
 
 # Maximum concurrent unauthenticated connections (start:rate:full)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,19 +1,47 @@
 ---
-sshd_protocol: 2
-sshd_ports: [ 22 ]
 
+# TCP port number that sshd listens on
+sshd_port: 22
+
+# IPs to listen on (useful for restricting SSH on multi-homed servers)
+sshd_listen_addresses: []
+
+# Only allow certain users to connect (default empty, allows all users)
+sshd_allowusers: []
+
+# Force certain groups of users to be SFTP-only (default empty, no users are forced to use SFTP)
 sshd_sftp_only_groups: []
 
-sshd_permit_root: yes
-sshd_password_auth: yes
-sshd_challenge_response_auth: yes
-sshd_gssapi_auth: yes
-sshd_gssapi_cleanup_credentials: yes
+# Whether root can log in
+sshd_permit_root: no
 
+# Whether password authentication is allowed (RFC4252)
+sshd_password_auth: no
+
+# Allows 'keyboard-interactive' authentication (RFC4256)
+sshd_challenge_response_auth: no
+
+# Whether user authentication based on GSSAPI is allowed (needed for Kerberos)
+sshd_gssapi_auth: no
+
+# Destroy user's credentials on logout
+sshd_gssapi_cleanup_credentials: no
+
+# Maximum concurrent unauthenticated connections (start:rate:full)
 sshd_maxstartups: "10:30:100"
 
-sshd_use_dns: yes 
+# Verify that reverse DNS lookup matches the IP address back
+sshd_use_dns: no
+
+# Use PAM (don't change unless using other authentication methods)
 sshd_use_pam: yes
-sshd_x11_forwarding: yes
+
+# Allow X11 forwarding over SSH
+
+sshd_x11_forwarding: no
+
+# Print /etc/motd when user logs in interactively
 sshd_print_motd: yes
-sshd_log_level: 'VERBOSE'
+
+# Verbosity level (valid values: QUIET, FATAL, ERROR, INFO, VERBOSE, DEBUG, DEBUG1, DEBUG2, and DEBUG3)
+sshd_log_level: 'INFO'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,6 @@
 ---
 galaxy_info:
-  author: OCAD University
   description: Configures the OpenSSH daemon
-  company: OCAD University
   license: MIT
   min_ansible_version: 2.0
   platforms:

--- a/molecule.yml
+++ b/molecule.yml
@@ -9,8 +9,8 @@ vagrant:
     - name: virtualbox
       type: virtualbox
       options:
-        memory: 512
-        cpus: 2
+        memory: 256
+        cpus: 1
   instances:
     - name: ansible-sshd
 verifier:

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: vagrant
+vagrant:
+  platforms:
+    - name: centos
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 2
+  instances:
+    - name: ansible-sshd
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,11 @@
+- hosts: all
+
+  pre_tasks:
+
+    - name: Install test dependencies
+      package:
+        name: net-tools
+        state: present
+
+  roles:
+    - role: ansible-sshd

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-ansible-lint
-docker-py
-flake8
-molecule
+molecule == 1.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ansible-lint
+docker-py
+flake8
+molecule

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Install packages
+  package:
+    name: '{{ item }}'
+    state: present
+  with_items: '{{ sshd_packages }}'
+
 - name: Copy configuration file
   template:
     src: sshd_config.j2
@@ -8,20 +14,16 @@
     group: root
     mode: '0600'
     backup: yes
-  register: sshd_config_copy
-
-- name: Verify configuration before restarting daemon
-  command: /usr/sbin/sshd -t
-  register: ssh_test
-  failed_when: ssh_test.rc != 0
   notify:
     - restart sshd
 
-- name: Reset SELinux ssh_port_t list
-  command: "/usr/sbin/semanage port -D ssh_port_t"
-  when: ansible_selinux.status == "enabled"
+- name: Validate configuration file is healthy
+  command: /usr/sbin/sshd -t
+  changed_when: false
 
-- name: Update ssh_port_t with additional ports
-  command: "/usr/sbin/semanage port -a -t ssh_port_t -p tcp {{ item }}"
-  with_items: '{{ sshd_ports }}'
-  when: ansible_selinux.status == "enabled" and sshd_ports|difference([22])
+- name: Add port to SELinux ssh_port_t
+  seport:
+    ports: '{{ sshd_port }}'
+    proto: tcp
+    setype: ssh_port_t
+    state: present

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -1,20 +1,13 @@
-Protocol {{ sshd_protocol }}
+Protocol 2
+Port {{ sshd_port }}
 
-{% for item in sshd_ports %}
-Port {{ item }}
-{% endfor %}
-
-{% if sshd_listen_ips is defined %}
-{% for item in sshd_listen_ips %}
+{% for item in sshd_listen_addresses %}
 ListenAddress {{ item }}
 {% endfor %}
-{% endif %}
 
-{% if sshd_allowusers is defined %}
 {% for item in sshd_allowusers %}
 AllowUsers {{ item }}
 {% endfor %}
-{% endif %}
 
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -27,7 +27,7 @@ def test_sshd_process(Process):
     assert len(p) >= 1
 
 
-# FIX: Port to be tested should be retrieve from Ansible variables
+# FIX: Port to be tested should be retrieved from Ansible variables
 def test_sshd_socket(Socket):
     s = Socket("tcp://0.0.0.0:22")
 

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,34 @@
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_sshd_config_file(File):
+    f = File('/etc/ssh/sshd_config')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0o600
+
+
+def test_sshd_service(Service):
+    s = Service('sshd')
+
+    assert s.is_enabled
+    assert s.is_running
+
+
+def test_sshd_process(Process):
+    p = Process.filter(user='root', comm='sshd')
+
+    assert len(p) >= 1
+
+
+# FIX: Port to be tested should be retrieve from Ansible variables
+def test_sshd_socket(Socket):
+    s = Socket("tcp://0.0.0.0:22")
+
+    assert s.is_listening

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,5 @@
+---
+
+sshd_packages:
+  - openssh-server
+  - policycoreutils-python


### PR DESCRIPTION
The goal was to simplify (remove cruft, things never used), better docs and adding molecule tests.

- defaults: Added comments (based on sshd_config man page)
- defaults: Added empty lists for better documentation and template simplification (instead of testing if variables were defined)
- defaults: Set defaults to the IDRC's default (instead of sshd_config defaults)
- defaults: Changed LogLevel from 'VERBOSE' (this was probably a mistake) to 'INFO' (default)
- defaults: Dropped support for choosing SSH protocol (v1 is insecure, there's no v3)
- defaults: Dropped support for choosing multiple ports (never ever used)
- tasks: Ensure packages are installed (previously, assumed this was the case, which it's not inside Docker and official Vagrant CentOS images)
- tasks: Switched from manually setting SELinux to using 'seport' module (introduced in Ansible 2.0 after this role was created)
- tasks: Notify restart handler on config file change
- tasks: Fail hard if sshd_config doesn't pass validity test (sshd -t)
- tests: Add initial molecule tests (package, service, process, port) using Vagrant
- README: Refer to defaults/main.yml instead of duplicating data